### PR TITLE
Merge-in fixes to this great plugin: Py3 support, etc

### DIFF
--- a/octoprint_snapstream/__init__.py
+++ b/octoprint_snapstream/__init__.py
@@ -26,7 +26,7 @@ class SnapStreamPlugin(TemplatePlugin, AssetPlugin, SettingsPlugin):
 
 				# use github release method of version check
 				type="github_release",
-				user="tonysurma",
+				user="markwal",
 				repo="OctoPrint-SnapStream",
 				current=self._plugin_version,
 

--- a/octoprint_snapstream/__init__.py
+++ b/octoprint_snapstream/__init__.py
@@ -36,6 +36,7 @@ class SnapStreamPlugin(TemplatePlugin, AssetPlugin, SettingsPlugin):
 		)
 
 __plugin_name__ = "SnapStream"
+__plugin_pythoncompat__ = ">=2.7,<4"
 
 def __plugin_load__():
 	global __plugin_implementation__

--- a/octoprint_snapstream/__init__.py
+++ b/octoprint_snapstream/__init__.py
@@ -26,7 +26,7 @@ class SnapStreamPlugin(TemplatePlugin, AssetPlugin, SettingsPlugin):
 
 				# use github release method of version check
 				type="github_release",
-				user="markwal",
+				user="tonysurma",
 				repo="OctoPrint-SnapStream",
 				current=self._plugin_version,
 

--- a/octoprint_snapstream/static/js/snapstream.js
+++ b/octoprint_snapstream/static/js/snapstream.js
@@ -6,6 +6,7 @@ $(function() {
         self.control = parameters[1];
         self.tab = "";
         self.online = true;
+        self.locked = false;
         self.failureCounter = 0;
         self.webcamImage = $("#webcam_image");
 
@@ -36,7 +37,11 @@ $(function() {
             var currentSrc = self.webcamImage.attr("src");
             if (currentSrc !== undefined && currentSrc.trim() != "") {
                 if (self.online) {
-                    self.webcamImage.attr("src", self.appendNoCacheMarker(self.settings.url()));
+                    if (!self.locked) {
+                      self.locked = true;
+                      self.webcamImage.load(function(){ self.locked = false;});         
+                      self.webcamImage.attr("src", self.appendNoCacheMarker(self.settings.url()));
+                  }
                 }
                 if (self.failureCounter < 4) {
                     self.webcamUpdateTimeout = setTimeout(self.webcamUpdate, 1000 / self.settings.fps());

--- a/octoprint_snapstream/static/js/snapstream.js
+++ b/octoprint_snapstream/static/js/snapstream.js
@@ -49,7 +49,7 @@ $(function() {
 
         self.onTabChange = function (current, previous) {
             self.tab = current;
-            if (current == "#control") {
+            if (current == "#control" || current == "#tab_plugin_consolidate_temp_control") {
                 if (self.settings.fallbackonly()) {
                     self.webcamImage.one("error", self.snapStream);
                 } else {

--- a/octoprint_snapstream/static/js/snapstream.js
+++ b/octoprint_snapstream/static/js/snapstream.js
@@ -60,7 +60,7 @@ $(function() {
         };
 
         self.onBrowserTabVisibilityChange = function(status) {
-            if (status && (self.tab == "#control" || self.tab == "#tab_plugin_consolidate_temp_control") {
+            if (status && (self.tab == "#control" || self.tab == "#tab_plugin_consolidate_temp_control")) {
                 self.onTabChange("#control", "");
             }
         }

--- a/octoprint_snapstream/static/js/snapstream.js
+++ b/octoprint_snapstream/static/js/snapstream.js
@@ -60,7 +60,7 @@ $(function() {
         };
 
         self.onBrowserTabVisibilityChange = function(status) {
-            if (status && self.tab == "#control") {
+            if (status && (self.tab == "#control" || self.tab == "#tab_plugin_consolidate_temp_control") {
                 self.onTabChange("#control", "");
             }
         }


### PR DESCRIPTION
I went through and consolidated all the separate forked changes I found, made a branch, and here's the pull request to update master. The fixes are:

1. Allow python 3 since this is all JavaScript anyways (jw59)
2. Update the stream in consolidated temp and control tab (Tony Surma)
3. Avoid image loading before brevious snapshot was completely loaded (sidddy)